### PR TITLE
Added documentation on using Notifications on KaiOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,13 @@ TBD
 
 ## Notifications
 
-TBD
+Notifications are provided by KaiOS itself when you use the standard [Notifications API](https://developer.mozilla.org/en-US/docs/Web/API/notification) while your app is running, or the [Push API](https://developer.mozilla.org/en-US/docs/Web/API/Push_API) if you want push notifications. Installed apps need to request permission for this through the manifest file. Just add this line to the permissions section of your `manifest.webapp` file.
+
+```
+"desktop-notification": {}
+```
+
+Once this is added, you can send the user notifications without needing to request permission.
 
 ## Themes
 


### PR DESCRIPTION
Noticed a section in the README about Notifications. There's no need to actually implement notifications in KaiUI, as it just uses standard web APIs, so I've added some docs to that effect.