### PR TITLE
Fixes parsing error

### DIFF
--- a/src/components/TextInput/TextInput.jsx
+++ b/src/components/TextInput/TextInput.jsx
@@ -16,7 +16,7 @@ const TextInput = ({
   onChange,
   enableTabSwitching,
   initialValue,
-  ...props,
+  ...props
 }) => {
   const [isFocused, setIsFocused] = useState(false);
   const [caretPosition, setCaretPosition] = useState(0);


### PR DESCRIPTION
```
Failed to compile.

./src/components/TextInput/TextInput.jsx
  Line 19:11:  Parsing error: Rest element must be last element

  17 |   enableTabSwitching,
  18 |   initialValue,
> 19 |   ...props,
     |           ^
  20 | }) => {
  21 |   const [isFocused, setIsFocused] = useState(false);
  22 |   const [caretPosition, setCaretPosition] = useState(0);
```
```
$ yarn -v
1.3.2
$ node -v
v12.14.0
```