### PR TITLE
Allow single child element in list view and narrowing typing

### DIFF
--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,0 +1,3 @@
+import { ReactElement } from "react";
+
+export type ReactElements = ReactElement | ReactElement[];

--- a/src/views/HorizontalListView/HorizontalListView.tsx
+++ b/src/views/HorizontalListView/HorizontalListView.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import ReactDOM from 'react-dom';
 import './HorizontalListView.scss';
 import classNames from 'classnames';
@@ -88,7 +88,7 @@ const HorizontalListView = React.memo<any>(
 
     const renderChildren = () => {
       let index = -1;
-      return React.Children.map(children, child => {
+      return React.Children.map(children, (child:ReactElement) => {
         // Don't focus on separators
         if (!child || child.props.separatorText != null) {
           return child;

--- a/src/views/ListView/ListView.tsx
+++ b/src/views/ListView/ListView.tsx
@@ -1,11 +1,12 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
+import { ReactElements } from './../../utils/types'
 import ReactDOM from 'react-dom';
 import './ListView.scss';
 import classNames from 'classnames';
 
 interface LocalProps {
   isActive?: boolean;
-  children: any[];
+  children: ReactElements;
   onChangeIndex?: (index: number) => void;
   className?: string;
 }
@@ -89,7 +90,7 @@ const ListView = React.memo<LocalProps>(
 
     const renderChildren = () => {
       let index = -1;
-      return React.Children.map(children, child => {
+      return React.Children.map(children, (child:ReactElement) => {
         // Don't focus on separators
         if (!child || child.props.separatorText != null) {
           return child;

--- a/src/views/ScrollingListView/ScrollingListView.tsx
+++ b/src/views/ScrollingListView/ScrollingListView.tsx
@@ -1,12 +1,13 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import './ScrollingListView.scss';
 import classNames from 'classnames';
 import BodyTextListItem from '../../components/BodyTextListItem/BodyTextListItem';
+import { ReactElements } from '../../utils/types';
 
 const prefixCls = 'kai-scroll-list-view';
 
 interface LocalProps {
-  children: any[];
+  children: ReactElements;
   onChangeIndex?: (index: number) => void;
   isActive: boolean;
   className?: string;
@@ -16,12 +17,13 @@ interface LocalProps {
 const ScrollingListView = React.memo<LocalProps>(
   (props) => {
     const {
-      children,
       onChangeIndex,
       isActive,
       className,
       initialSelectedIndex
     } = props;
+
+    const children:ReactElement[] = [].concat(props.children);
 
     const [activeItem, setActiveItem] = useState(initialSelectedIndex === undefined ? 1 : initialSelectedIndex);
 

--- a/src/views/TabView/TabView.tsx
+++ b/src/views/TabView/TabView.tsx
@@ -1,9 +1,10 @@
-import React, { useState } from 'react';
+import React, { ReactElement, ReactEventHandler, useState } from 'react';
 import SwipeableViews from 'react-swipeable-views';
 import Tabs from '../../components/Tabs/Tabs';
 import Tab from '../../components/Tab/Tab';
 import colors from '../../theme/colors.scss';
 import './TabView.scss';
+import { ReactElements } from '../../utils/types';
 
 const prefixCls = 'kai-tab-view';
 
@@ -11,7 +12,7 @@ interface LocalProps {
   tabLabels: string[],
   onChangeIndex?: (index: number) => void,
   focusColor?: string,
-  children: any[]
+  children: ReactElements
 }
 
 const TabView = React.memo<LocalProps>(
@@ -54,7 +55,7 @@ const TabView = React.memo<LocalProps>(
     };
 
     const renderChildren = () => {
-      return React.Children.map(children, (child:any, i) => {
+      return React.Children.map(children, (child:ReactElement, i) => {
         return React.cloneElement(child, {
           isActive: activeTab === i && isTransitionDone,
         });

--- a/src/views/TriColumnListView/TriColumnListView.tsx
+++ b/src/views/TriColumnListView/TriColumnListView.tsx
@@ -1,16 +1,16 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, ReactElement } from 'react';
 import './TriColumnListView.scss';
-import ListView from '../ListView/ListView';
 import ScrollingListView from '../ScrollingListView/ScrollingListView';
+import { ReactElements } from '../../utils/types';
 
 const prefixCls = 'kai-tricol-view';
 
 interface LocalProps {
   onChangeIndex?: (index: number) => void,
   focusColor?: string,
-  col1Children: any[],
-  col2Children: any[],
-  col3Children: any[],
+  col1Children: ReactElements,
+  col2Children: ReactElements,
+  col3Children: ReactElements,
   onCol1ChangeIndex?: (index: number) => void,
   onCol2ChangeIndex?: (index: number) => void,
   onCol3ChangeIndex?: (index: number) => void,
@@ -75,8 +75,8 @@ const TriColListView = React.memo<LocalProps>(
       [handleKeyDown]
     );
 
-    const renderChildren = (children) => {
-      return React.Children.map(children, (child:any, i) => {
+    const renderChildren = (children: ReactElements) => {
+      return React.Children.map(children, (child:ReactElement, i) => {
         return React.cloneElement(child, {
           isActive: activeTab === i && isTransitionDone,
           onFocusChange: handleChangeIndex,


### PR DESCRIPTION
After TS was introduced, children components for views component (ListView, and others) were set to any[], which from one hand not allows to use it with single child, which is very much valid use case (see ss):

![before_fix](https://user-images.githubusercontent.com/2708524/113612940-c6b17200-9650-11eb-8ecf-0d3323d2138c.png)

On the other hand it doesn't support 'any' children, but rather children, that have props (I guess it should be ReactElement).

I tested fix with example app: 
![after_fix](https://user-images.githubusercontent.com/2708524/113613117-04ae9600-9651-11eb-91b7-6fe60953bfdd.png)
![still_works](https://user-images.githubusercontent.com/2708524/113613121-05dfc300-9651-11eb-8443-de8b05ee8f30.png)

I'm new to both React and TS, so please let me know if the fix I provided is not optimal or is not according to common React/TS practices